### PR TITLE
Allow to append to arrays

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
-gem "kubeclient", '>= 1.1.4'
+gem "kubeclient", '~> 2.5.0'
+gem "recursive-open-struct", "1.0.5"
 
 group :test do
   gem "rake", "~> 10.0"

--- a/lib/puppet_x/puppetlabs/swagger/fuzzy_compare.rb
+++ b/lib/puppet_x/puppetlabs/swagger/fuzzy_compare.rb
@@ -15,7 +15,7 @@ module PuppetX
         private
         def self.do_compare(normalized_should, normalized_is)
           klass = normalized_should.class
-          if [String, Integer, TrueClass, FalseClass, NilClass].include? klass
+          if [String, Integer, Fixnum, TrueClass, FalseClass, NilClass].include? klass
             normalized_should.to_s == normalized_is.to_s
           elsif klass == Array
             if normalized_is.class != Array || normalized_should.length != normalized_is.length


### PR DESCRIPTION
The current code wasn't correct, because Ruby has no `append` methods
for arrays, and also because it was impossible to add an element to an
array that didn't exist yet (like for instance adding a volume to a podspec
that didn't had any volumes yet).