### PR TITLE
Prevent Ruby 2.4 deprecated Fixnum warning

### DIFF
--- a/lib/puppet_x/puppetlabs/kubernetes/provider.rb
+++ b/lib/puppet_x/puppetlabs/kubernetes/provider.rb
@@ -112,7 +112,7 @@ module PuppetX
           end
 
           def get(attr)
-            if attr.is_a?(Fixnum)
+            if attr.is_a?(Numeric)
               if @object.nil?
                 @object = []
                 @parent_setter.call(@object)

--- a/lib/puppet_x/puppetlabs/swagger/fuzzy_compare.rb
+++ b/lib/puppet_x/puppetlabs/swagger/fuzzy_compare.rb
@@ -15,7 +15,7 @@ module PuppetX
         private
         def self.do_compare(normalized_should, normalized_is)
           klass = normalized_should.class
-          if [String, Integer, Fixnum, TrueClass, FalseClass, NilClass].include? klass
+          if [String, 0.class, TrueClass, FalseClass, NilClass].include? klass
             normalized_should.to_s == normalized_is.to_s
           elsif klass == Array
             if normalized_is.class != Array || normalized_should.length != normalized_is.length


### PR DESCRIPTION
That I reintroduced because running ruby 2.3.